### PR TITLE
improv: Compile gresources into binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "gdk4-wayland",
  "gdk4-x11",
  "gettext-rs",
+ "gio",
  "gtk4",
  "i18n-embed",
  "i18n-embed-fl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ i18n-embed = { version = "0.13.4", features = ["fluent-system", "desktop-request
 i18n-embed-fl = "0.6.4"
 rust-embed = "6.3.0"
 
+[build-dependencies]
+gio = "0.15.10"
+
 [profile.release]
 incremental = true
 debug = 1

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,7 @@
-#[cfg(feature = "dev")]
-use std::process::Command;
-
-#[cfg(feature = "dev")]
 fn main() {
-    Command::new("mkdir")
-        .args(["-p", "target/"])
-        .output()
-        .expect("failed to create target/");
-    Command::new("glib-compile-resources")
-        .args([
-            "--sourcedir=data/resources",
-            "--target=target/compiled.gresource",
-            "data/resources/resources.gresource.xml",
-        ])
-        .output()
-        .expect("failed to compile gresources");
+    gio::compile_resources(
+        "data/resources",
+        "data/resources/resources.gresource.xml",
+        "compiled.gresource",
+    );
 }
-
-#[cfg(not(feature = "dev"))]
-pub fn main() {}

--- a/i18n/es/cosmic_app_library.ftl
+++ b/i18n/es/cosmic_app_library.ftl
@@ -1,0 +1,7 @@
+cosmic-app-library = Bibliotea de Aplicaciones Cosmic
+system = Sistema
+utilities = Utilidades
+new-group = Nuevo Grupo
+name = Nombre
+ok = Ok
+cancel = Cancelar

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ sharedir := rootdir + prefix + '/share'
 iconsdir := sharedir + '/icons/hicolor/scalable/apps'
 bindir := rootdir + prefix + '/bin'
 
-all: _extract_vendor _compile_gresource
+all: _extract_vendor
     cargo build {{cargo_args}}
 
 # Installs files into the system
@@ -23,7 +23,6 @@ install:
     install -Dm0644 data/icons/{{id}}.Devel.svg {{iconsdir}}/{{id}}.Devel.svg
     install -Dm0644 data/icons/{{id}}.svg {{iconsdir}}/{{id}}.svg
     install -Dm0644 data/{{id}}.desktop {{sharedir}}/applications/{{id}}.desktop
-    install -Dm0644 target/compiled.gresource {{sharedir}}/{{id}}/compiled.gresource
     install -Dm04755 target/release/cosmic-app-library {{bindir}}/cosmic-app-library
 
 # Extracts vendored dependencies if vendor=1
@@ -32,11 +31,3 @@ _extract_vendor:
     if test {{vendor}} = 1; then
         rm -rf vendor; tar pxf vendor.tar
     fi
-
-# Compiles the gresources file
-_compile_gresource:
-    mkdir -p target/
-    glib-compile-resources --sourcedir=data/resources \
-        --target=target/compiled.gresource \
-        data/resources/resources.gresource.xml 
-        

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,2 @@
 pub const APP_ID: &str = "com.System76.CosmicAppLibrary";
-#[cfg(feature = "dev")]
-pub const RESOURCES_FILE: &str = concat!("target/compiled.gresource");
-#[cfg(not(feature = "dev"))]
-pub const RESOURCES_FILE: &str = concat!("/usr/share/com.System76.CosmicAppLibrary/compiled.gresource");
 pub const VERSION: &str = "0.0.1";

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ mod window_inner;
 use gtk4::{gio, glib};
 
 use self::application::CosmicAppLibraryApplication;
-use self::config::RESOURCES_FILE;
 
 pub fn localize() {
     let localizer = crate::localize::localizer();
@@ -35,8 +34,7 @@ fn main() {
 
     localize();
 
-    let res = gio::Resource::load(RESOURCES_FILE).expect("Could not load gresource file");
-    gio::resources_register(&res);
+    gio::resources_register_include!("compiled.gresource").unwrap();
 
     let app = CosmicAppLibraryApplication::new();
     app.run();


### PR DESCRIPTION
As far as I'm aware, gresources are usually compiled into the binary. Gtk-rs makes this fairly easy.

`gio::compile_resources` also instructs Cargo to watch for changes to files used as resources, and re-run `build.rs` is any have changed.

(You see, I'm somewhat fond of `gio::compile_resources` since I'm the one who added it to gtk-rs).