### PR TITLE
Update desktop file to toggle visibility over dbus

### DIFF
--- a/data/com.system76.CosmicAppLibrary.desktop
+++ b/data/com.system76.CosmicAppLibrary.desktop
@@ -2,7 +2,7 @@
 Name=Cosmic App Library
 Comment=COSMIC App Library shell application
 Type=Application
-Exec=cosmic-app-library
+Exec=busctl --user call com.system76.CosmicAppLibrary /com/system76/CosmicAppLibrary com.system76.CosmicAppLibrary Toggle
 Terminal=false
 Categories=COSMIC;ICED;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!


### PR DESCRIPTION
The desktop file doesn't seem to be used by cosmic-session. Now that this isn't using xdg-shell-wrapper, it doesn't seem to serve a purpose.

It can instead be used to send the dbus command to toggle the app library, which is useful for
https://github.com/pop-os/cosmic-applets/pull/78.