### PR TITLE
Fix icons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-icons"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e61ac115df4632b592d36b71fda3c259f4c8061c70b7fa429bac145890e880"
+checksum = "3f9d46a9ae065c46efb83854bb10315de6d333bb6f4526ebe320c004dab7857e"
 dependencies = [
  "dirs 4.0.0",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ron = "0.8.0"
 notify = "*"
 anyhow = "1.0"
 itertools = "0.11"
-freedesktop-icons = "0.2.2"
+freedesktop-icons = "0.2.4"
 current_locale = "0.1.1"
 url = "2.4"
 

--- a/src/app_group.rs
+++ b/src/app_group.rs
@@ -81,39 +81,46 @@ impl AppGroup {
                                     .unwrap_or_default()
                         }
                         if keep_de {
-                            freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
+                            let icon = freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
                                 .with_size(72)
                                 .with_cache()
                                 .find()
-                                .map(|icon| DesktopEntryData {
-                                    id: de.appid.to_string(),
-                                    exec: exec.to_string(),
-                                    name,
-                                    icon,
-                                    path: path.clone(),
-                                    desktop_actions: de
-                                        .actions()
-                                        .map(|actions| {
-                                            actions
-                                                .split(";")
-                                                .filter_map(|action| {
-                                                    let name = de.action_entry_localized(
-                                                        action, "Name", locale,
-                                                    );
-                                                    let exec = de.action_entry(action, "Exec");
-                                                    if let (Some(name), Some(exec)) = (name, exec) {
-                                                        Some(DesktopAction {
-                                                            name: name.to_string(),
-                                                            exec: exec.to_string(),
-                                                        })
-                                                    } else {
-                                                        None
-                                                    }
-                                                })
-                                                .collect_vec()
-                                        })
-                                        .unwrap_or_default(),
+                                .or_else(|| {
+                                    freedesktop_icons::lookup("application-default")
+                                        .with_size(72)
+                                        .with_cache()
+                                        .find()
                                 })
+                                .unwrap_or_default();
+
+                            Some(DesktopEntryData {
+                                id: de.appid.to_string(),
+                                exec: exec.to_string(),
+                                name,
+                                icon,
+                                path: path.clone(),
+                                desktop_actions: de
+                                    .actions()
+                                    .map(|actions| {
+                                        actions
+                                            .split(";")
+                                            .filter_map(|action| {
+                                                let name = de
+                                                    .action_entry_localized(action, "Name", locale);
+                                                let exec = de.action_entry(action, "Exec");
+                                                if let (Some(name), Some(exec)) = (name, exec) {
+                                                    Some(DesktopAction {
+                                                        name: name.to_string(),
+                                                        exec: exec.to_string(),
+                                                    })
+                                                } else {
+                                                    None
+                                                }
+                                            })
+                                            .collect_vec()
+                                    })
+                                    .unwrap_or_default(),
+                            })
                         } else {
                             None
                         }


### PR DESCRIPTION
- Update freedesktop-icons to the latest release, which includes a couple of fixes to the icon lookup function
- Avoid's discarding valid desktop entries, whos icons can't be found and replaces the icon with the generic application icon