### PR TITLE
Fix fallback icon

### DIFF
--- a/src/app_group.rs
+++ b/src/app_group.rs
@@ -87,7 +87,15 @@ impl AppGroup {
                                 .find()
                                 .or_else(|| {
                                     freedesktop_icons::lookup("application-default")
-                                        .with_size(72)
+                                        .with_theme("Cosmic")
+                                        .force_svg()
+                                        .with_cache()
+                                        .find()
+                                })
+                                .or_else(|| {
+                                    freedesktop_icons::lookup("application-x-application")
+                                        .with_theme("default")
+                                        .with_size(128)
                                         .with_cache()
                                         .find()
                                 })


### PR DESCRIPTION
This fixes the icon fallback from https://github.com/pop-os/cosmic-applibrary/pull/52, as `application-default` is an icon specific to our icon themes. (See https://github.com/pop-os/launcher/pull/195/commits/ddf4936d25ba8e8263d893180f9281eacb78249d for a similar fix.)