### PR TITLE
Increase max height

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1082,7 +1082,12 @@ impl cosmic::Application for CosmicAppLibrary {
                 column(app_grid_list)
                     .width(Length::Fill)
                     .spacing(spacing.space_xxs)
-                    .padding([spacing.space_none, spacing.space_xxl]),
+                    .padding([
+                        spacing.space_none,
+                        spacing.space_xxl,
+                        spacing.space_xxs,
+                        spacing.space_xxl,
+                    ]),
             )
             .on_scroll(|viewport| Message::ScrollYOffset(viewport.absolute_offset().y))
             .id(Id::new(
@@ -1218,7 +1223,7 @@ impl cosmic::Application for CosmicAppLibrary {
         let window = container(content)
             .width(Length::Fill)
             .height(Length::Fill)
-            .max_height(684)
+            .max_height(685)
             .max_width(1200.0)
             .style(theme::Container::Custom(Box::new(|theme| {
                 container::Appearance {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1218,7 +1218,7 @@ impl cosmic::Application for CosmicAppLibrary {
         let window = container(content)
             .width(Length::Fill)
             .height(Length::Fill)
-            .max_height(656)
+            .max_height(684)
             .max_width(1200.0)
             .style(theme::Container::Custom(Box::new(|theme| {
                 container::Appearance {


### PR DESCRIPTION
Should close #116, and maybe #89 (can't test this since it takes my entire screen at 200%, and only 2 rows fit).
Tuned the value to not have the highlight of the hovered app touch the edge, and to not be able to accidentally launch apps in the 4th row (when no icon is visible, but the top of the highlight is clickable).

Unrelated, but maybe a small issue on Pop: when running `sudo apt reinstall cosmic-*`, this message is shown
`E: Unable to locate package cosmic-applibrary`, which might be because the repo name is different from the package name in Pop.