### PR TITLE
Update for `spawn_desktop_exec` that calls `SpawnTransientUnit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -117,33 +117,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -219,9 +219,26 @@ dependencies = [
  "serde_repr",
  "tokio",
  "url",
+ "zbus 4.4.0",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe7e0dd0ac5a401dc116ed9f9119cf9decc625600474cb41f0fc0a0050abc9a"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "zbus 4.4.0",
 ]
 
@@ -701,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.10"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -711,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.10"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -723,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -735,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clipboard-win"
@@ -825,9 +842,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "com"
@@ -964,7 +981,7 @@ dependencies = [
 [[package]]
 name = "cosmic-app-list-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-applets#c6291c7c093e78dc21c3854a988b04db62106d6b"
+source = "git+https://github.com/pop-os/cosmic-applets#478bb3e500ab1d9e7cbaa1d4d7695d137fbeac8c"
 dependencies = [
  "libcosmic",
  "serde",
@@ -984,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1006,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1015,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#1d0e48f7d418a661c9eeca2802529e4606d349ff"
+source = "git+https://github.com/pop-os/cosmic-panel#d5fc4ddef106bf2bdaf983028f78b9d8e432b3ae"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1035,7 +1052,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.3",
+ "wayland-protocols",
  "wayland-protocols-wlr",
  "wayland-scanner",
  "wayland-server",
@@ -1074,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1783,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.14.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a78dd758a47a7305478e0e054f9fde4e983b9f9eccda162bf7ca03b79e9d40"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
@@ -2231,7 +2248,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "toml 0.8.15",
+ "toml 0.8.16",
  "unic-langid",
 ]
 
@@ -2317,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2335,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2344,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "bitflags 2.6.0",
  "dnd",
@@ -2366,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "futures",
  "iced_core",
@@ -2379,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2403,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2415,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2429,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2445,7 +2462,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "wayland-backend",
- "wayland-protocols 0.32.3",
+ "wayland-protocols",
  "window_clipboard",
  "xkbcommon",
  "xkbcommon-dl",
@@ -2455,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2465,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2482,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2502,7 +2519,7 @@ dependencies = [
  "tiny-xlib",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.3",
+ "wayland-protocols",
  "wayland-sys",
  "wgpu",
  "x11rb",
@@ -2511,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2653,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -2784,10 +2801,10 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a5996b4e90f6aad943b7c61b961fae5edacd7697"
+source = "git+https://github.com/pop-os/libcosmic/#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "apply",
- "ashpd",
+ "ashpd 0.9.1",
  "chrono",
  "cosmic-client-toolkit",
  "cosmic-config",
@@ -2810,11 +2827,12 @@ dependencies = [
  "iced_wgpu",
  "iced_widget",
  "lazy_static",
+ "libc",
  "mime 0.3.17",
- "nix 0.27.1",
  "palette",
  "rfd",
  "ron",
+ "rustix 0.38.34",
  "serde",
  "shlex",
  "slotmap",
@@ -3122,17 +3140,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -3872,7 +3879,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251"
 dependencies = [
- "ashpd",
+ "ashpd 0.8.1",
  "block",
  "dispatch",
  "js-sys",
@@ -4119,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -4239,7 +4246,7 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.32.3",
+ "wayland-protocols",
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkbcommon",
@@ -4625,21 +4632,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.16",
+ "toml_edit 0.22.17",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
 dependencies = [
  "serde",
 ]
@@ -4668,15 +4675,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.16"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
+checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.15",
+ "winnow 0.6.16",
 ]
 
 [[package]]
@@ -5098,18 +5105,6 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62989625a776e827cc0f15d41444a3cea5205b963c3a25be48ae1b52d6b4daaa"
@@ -5130,7 +5125,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.3",
+ "wayland-protocols",
  "wayland-scanner",
  "wayland-server",
 ]
@@ -5521,9 +5516,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.15"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557404e450152cd6795bb558bca69e43c585055f4606e3bcae5894fc6dac9ba0"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]
@@ -5574,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#1d0e48f7d418a661c9eeca2802529e4606d349ff"
+source = "git+https://github.com/pop-os/cosmic-panel#d5fc4ddef106bf2bdaf983028f78b9d8e432b3ae"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",


### PR DESCRIPTION
Allows `xdg-desktop-portal` to get app id from PID.

Depends on https://github.com/pop-os/libcosmic/pull/548.