### PR TITLE
fix: focus search on activation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -263,7 +263,6 @@ impl CosmicAppLibrary {
                 cosmic::app::Message::App(Message::GpuUpdate(gpus))
             });
             return Task::batch(vec![
-                text_input::focus(SEARCH_ID.clone()),
                 get_layer_surface(SctkLayerSurfaceSettings {
                     id: WINDOW_ID.clone(),
                     keyboard_interactivity: KeyboardInteractivity::OnDemand,
@@ -273,7 +272,8 @@ impl CosmicAppLibrary {
                     ..Default::default()
                 }),
                 fetch_gpus,
-            ]);
+            ])
+            .chain(text_input::focus(SEARCH_ID.clone()));
         }
         Task::none()
     }


### PR DESCRIPTION
The search field should be focused upon activation. Currently, `get_layer_surface()` and `text_input::focus` are run in parallel. This causes the focus operation to fail because it is executed before the layer_surface and thus the search field is ready. Modified the code, so that `text_input::focus()` is executed after the task of `get_layer_surface()` completed.

Fixes #184