### PR TITLE
fix: high CPU usage when desktop files are accessed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
  "cosmic-app-list-config",
  "cosmic-freedesktop-icons",
  "current_locale",
- "freedesktop-desktop-entry",
+ "freedesktop-desktop-entry 0.7.5",
  "futures",
  "glob",
  "i18n-embed",
@@ -1936,6 +1936,22 @@ dependencies = [
  "dirs 3.0.2",
  "gettext-rs",
  "memchr",
+ "thiserror",
+ "xdg",
+]
+
+[[package]]
+name = "freedesktop-desktop-entry"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83c9c25bc7e0ff18c6fee324db310497622be235fd45c0f7347ab81981a941e"
+dependencies = [
+ "dirs 5.0.1",
+ "gettext-rs",
+ "log",
+ "memchr",
+ "strsim 0.11.1",
+ "textdistance",
  "thiserror",
  "xdg",
 ]
@@ -3116,7 +3132,7 @@ dependencies = [
  "cosmic-theme",
  "css-color",
  "derive_setters",
- "freedesktop-desktop-entry",
+ "freedesktop-desktop-entry 0.5.2",
  "iced",
  "iced_accessibility",
  "iced_core",
@@ -5019,6 +5035,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textdistance"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa672c55ab69f787dbc9126cc387dbe57fdd595f585e4524cf89018fa44ab819"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ i18n-embed = { version = "0.14.1", features = [
 i18n-embed-fl = "0.8.0"
 rust-embed = "8.4.0"
 glob = "0.3.0"
-freedesktop-desktop-entry = "0.5.2"
+freedesktop-desktop-entry = "0.7.5"
 shlex = "1.1.0"
 serde = { version = "1.0.134", features = ["derive"] }
 ron = "0.8.0"


### PR DESCRIPTION
It doesn't fix the source of the issue which generates file access events in application folders during window resizes, but it does significantly reduce the CPU cost by only updating the applet when a desktop entry has been created, modified, or removed.