### PR TITLE
Use `KeyboardInteractivity::Exclusive`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -274,7 +274,7 @@ impl CosmicAppLibrary {
             return Task::batch(vec![
                 get_layer_surface(SctkLayerSurfaceSettings {
                     id: WINDOW_ID.clone(),
-                    keyboard_interactivity: KeyboardInteractivity::OnDemand,
+                    keyboard_interactivity: KeyboardInteractivity::Exclusive,
                     anchor: Anchor::all(),
                     namespace: "app-library".into(),
                     size: Some((None, None)),


### PR DESCRIPTION
Matches `cosmic-launcher` and `cosmic-workspaces`.

Fixes https://github.com/pop-os/cosmic-workspaces-epoch/issues/164.