### PR TITLE
Fix sorting order of application groups to include default groups

### DIFF
--- a/src/app_group.rs
+++ b/src/app_group.rs
@@ -86,6 +86,20 @@ impl Ord for AppGroup {
             (FilterType::AppIds(_), FilterType::AppIds(_)) => {
                 self.name.to_lowercase().cmp(&other.name.to_lowercase())
             }
+            (FilterType::Categories {categories,..}, FilterType::AppIds(_)) => {
+                if let Some(cat_name) = categories.first() {
+                    cat_name.to_lowercase().cmp(&other.name.to_lowercase())
+                } else {
+                    self.name.to_lowercase().cmp(&other.name.to_lowercase())
+                }
+            },
+            (FilterType::AppIds(_), FilterType::Categories {categories,..}) => {
+                if let Some(other_name) = categories.first() {
+                    self.name.to_lowercase().cmp(&other_name.to_lowercase())
+                } else {
+                    self.name.to_lowercase().cmp(&other.name.to_lowercase())
+                }
+            },
             (a, b) => a.cmp(b),
         }
     }


### PR DESCRIPTION
Sort order now respects names even if the filter types between app groups are different. This means that the "default" categories are sorted by name consistently with those created by users. 

<img width="1959" height="1119" alt="Screenshot_2025-10-12_23-35-27" src="https://github.com/user-attachments/assets/d316ef5c-f422-4d21-8c7b-511bc05b0aaf" />

Fixes: #226

Note: I would argue there's also a conveyance issue between groups with filters and groups without filters, though maybe I'm over thinking this. I think that the filtered categories groups should have a different icon than those with simple `AppIds` filters; it isn't clear to users that there are special rules between these two different categories. While users can't manually create custom categories with auto filters, it would at least be nice to convey that there's a difference in rules between the filters present by default and the ones that users can manually. A simple folder-with-magnifying-glass style icon would be nice enough, though I'd leave that to System76's graphic designers. :)  

