### PR TITLE
feat: add standalone run mode via 'just run'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "ron 0.12.0",
  "rust-embed",
  "serde",
+ "serde_json",
  "shlex",
  "smithay-client-toolkit 0.20.0",
  "switcheroo-control",

--- a/justfile
+++ b/justfile
@@ -33,6 +33,10 @@ build-release *args: (build-debug '--release' args)
 # Compiles release profile with vendored dependencies
 build-vendored *args: vendor-extract (build-release '--frozen --offline' args)
 
+# Compiles and runs a standalone instance
+run *args: build-release
+    {{bin-src}} run {{args}}
+
 # Runs a clippy check
 check *args:
     cargo clippy --all-features {{args}} -- -W clippy::pedantic


### PR DESCRIPTION
Adds `just run` command for local development that lets cosmic-app-library run standalone.