### PR TITLE
Enable wgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.3",
+ "rand 0.9.4",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -309,7 +309,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.3",
+ "rand 0.9.4",
  "serde",
  "serde_repr",
  "tokio",
@@ -1027,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "quote",
  "syn",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "almost",
  "configparser",
@@ -1440,7 +1440,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "dpi"
 version = "0.1.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 
 [[package]]
 name = "drm"
@@ -1727,9 +1727,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9237c6d82152100c691fb77ea18037b402bcc7257d2c876a4ffac81bc22a1c"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
 ]
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "futures",
  "iced_core",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2415,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
@@ -2479,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -2498,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "cosmic-client-toolkit",
  "cursor-icon",
@@ -2989,14 +2989,14 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#1d7113a2446ef11e57f2782ff3487a4975c6da90"
+source = "git+https://github.com/pop-os/libcosmic#52116d2f36972c422a0953a4699e32d5eb30cdac"
 dependencies = [
  "apply",
  "ashpd 0.12.3",
@@ -3941,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -4184,9 +4184,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -6420,7 +6420,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 [[package]]
 name = "winit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "bitflags 2.11.0",
  "cfg_aliases",
@@ -6446,7 +6446,7 @@ dependencies = [
 [[package]]
 name = "winit-android"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "android-activity",
  "bitflags 2.11.0",
@@ -6461,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "winit-appkit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
@@ -6483,7 +6483,7 @@ dependencies = [
 [[package]]
 name = "winit-common"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "memmap2 0.9.10",
  "objc2 0.6.4",
@@ -6498,7 +6498,7 @@ dependencies = [
 [[package]]
 name = "winit-core"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "bitflags 2.11.0",
  "cursor-icon",
@@ -6512,7 +6512,7 @@ dependencies = [
 [[package]]
 name = "winit-orbital"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "bitflags 2.11.0",
  "dpi",
@@ -6528,7 +6528,7 @@ dependencies = [
 [[package]]
 name = "winit-uikit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
@@ -6548,7 +6548,7 @@ dependencies = [
 [[package]]
 name = "winit-wayland"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "ahash",
  "bitflags 2.11.0",
@@ -6574,7 +6574,7 @@ dependencies = [
 [[package]]
 name = "winit-web"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "atomic-waker",
  "bitflags 2.11.0",
@@ -6596,7 +6596,7 @@ dependencies = [
 [[package]]
 name = "winit-win32"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "bitflags 2.11.0",
  "cursor-icon",
@@ -6612,7 +6612,7 @@ dependencies = [
 [[package]]
 name = "winit-x11"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#261cda54017f98a12dc55569c864430fe6770366"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.2"
 authors = ["Ashley Wulber <ashley@system76.com>"]
 edition = "2024"
 [features]
-default = []
+default = ["wgpu"]
 wgpu = ["libcosmic/wgpu"]
 
 [dependencies]


### PR DESCRIPTION
This reverts commit 3a7929744a474cb65dabcb1700d75250827487ec.
Scrolling in app-library is slow and choppy without gpu rendering.

- [x] Noticed an issue with dragging PNG icons: https://github.com/pop-os/iced/pull/325

wgpu was disabled in https://github.com/pop-os/cosmic-app-library/pull/307, but I'm pretty sure the issue https://github.com/pop-os/cosmic-app-library/issues/296 is fixed. I assume updating wgpu from 22 to 27 fixed it.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
