### PR TITLE
Properly show apps with long names

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -30,10 +30,8 @@ use cosmic::{
             data_device::ActionInner,
         },*/
         widget::{
-            column, container, mouse_area, row,
-            rule::horizontal as horizontal_rule,
+            column, container, mouse_area, row, rule::horizontal as horizontal_rule,
             scrollable::RelativeOffset,
-            space::{horizontal, vertical},
         },
         window::Event as WindowEvent,
     },
@@ -46,6 +44,7 @@ use cosmic::{
                 wayland::{self, LayerEvent},
             },
             keyboard::{Key, key::Named},
+            text::{Ellipsize, EllipsizeHeightLimit},
             widget::operation::{
                 self,
                 focusable::{find_focused, focus},
@@ -1354,11 +1353,21 @@ impl cosmic::Application for CosmicAppLibrary {
                             .on_clear(Message::EditName(String::new()))
                             .on_submit(|_| Message::SubmitName)
                             .id(EDIT_GROUP_ID.clone())
-                            .width(Length::Fixed(200.0))
+                            .width(Length::Fill)
                             .size(14),
                     )
+                    .width(Length::Fill)
+                    .center_x(Length::FillPortion(8))
                 } else {
-                    container(text(cur_group.name()).size(24))
+                    container(
+                        text(cur_group.name())
+                            .size(24)
+                            .width(Length::Fill)
+                            .center()
+                            .ellipsize(Ellipsize::End(EllipsizeHeightLimit::Lines(1))),
+                    )
+                    .width(Length::Fill)
+                    .center_x(Length::FillPortion(8))
                 },
                 row![
                     space::horizontal(),
@@ -1497,7 +1506,10 @@ impl cosmic::Application for CosmicAppLibrary {
                             .height(Length::Fixed(group_icon_size))
                     )
                     .padding(space_xxs),
-                    text::body(ADD_GROUP.as_str()).width(Length::Shrink)
+                    text::body(ADD_GROUP.as_str())
+                        .width(Length::Fill)
+                        .center()
+                        .ellipsize(Ellipsize::End(EllipsizeHeightLimit::Lines(1)))
                 ]
                 .align_x(Alignment::Center)
                 .width(Length::Fill),
@@ -1529,7 +1541,10 @@ impl cosmic::Application for CosmicAppLibrary {
                                         .height(Length::Fixed(group_icon_size))
                                 )
                                 .padding(space_xxs),
-                                text::body(group.name()).width(Length::Shrink)
+                                text::body(group.name())
+                                    .width(Length::Fill)
+                                    .center()
+                                    .ellipsize(Ellipsize::End(EllipsizeHeightLimit::Lines(1)))
                             ]
                             .align_x(Alignment::Center)
                             .width(Length::Fill),

--- a/src/widgets/application.rs
+++ b/src/widgets/application.rs
@@ -60,33 +60,20 @@ impl<'a, Message: Clone + 'static> ApplicationButton<'a, Message> {
             space_xxs, space_s, ..
         } = theme::active().cosmic().spacing;
 
-        let (source_icon, source_suffix_len) = match source {
-            Some((source, source_icon_handle)) => {
-                let source_name = source.to_string();
-                (
-                    source_icon_handle.as_ref().map(|i| {
-                        Element::from(
-                            container(app_source_icon(i.clone()))
-                                .class(cosmic::theme::Container::Card)
-                                .width(Length::Fixed(24.0))
-                                .height(Length::Fixed(24.0))
-                                .align_x(Horizontal::Center)
-                                .align_y(Vertical::Center),
-                        )
-                    }),
-                    source_name.len().saturating_add(3), // 3 for the parentheses
+        let source_icon = match source {
+            Some((_source, source_icon_handle)) => source_icon_handle.as_ref().map(|i| {
+                Element::from(
+                    container(app_source_icon(i.clone()))
+                        .class(cosmic::theme::Container::Card)
+                        .width(Length::Fixed(24.0))
+                        .height(Length::Fixed(24.0))
+                        .align_x(Horizontal::Center)
+                        .align_y(Vertical::Center),
                 )
-            }
-            None => (None, 0),
+            }),
+            None => None,
         };
-        let max_name_len = 27 - source_suffix_len;
-        let name = if name.len() > max_name_len {
-            if let Some((source, ..)) = source {
-                format!("{name:.17}... ({source})")
-            } else {
-                format!("{name:.24}...")
-            }
-        } else if let Some((source, ..)) = source {
+        let name = if let Some((source, ..)) = source {
             format!("{name} ({source})")
         } else {
             name.to_string()
@@ -100,12 +87,20 @@ impl<'a, Message: Clone + 'static> ApplicationButton<'a, Message> {
                         .icon()
                         .width(Length::Fixed(72.0))
                         .height(Length::Fixed(72.0)),
-                    container(text(name).size(14.0).width(Length::Shrink))
-                        .align_x(Horizontal::Center)
-                        .width(Length::Fill)
-                        .height(Length::Fixed(40.0))
+                    container(
+                        text(name)
+                            .size(14.0)
+                            .width(Length::Fill)
+                            .center()
+                            .wrapping(cosmic::iced::core::text::Wrapping::WordOrGlyph)
+                            .ellipsize(cosmic::iced::core::text::Ellipsize::End(
+                                cosmic::iced::core::text::EllipsizeHeightLimit::Lines(2),
+                            )),
+                    )
+                    .align_x(Horizontal::Center)
+                    .width(Length::Fill)
+                    .height(Length::Fixed(40.0))
                 ]
-                .width(Length::Fixed(120.0))
                 .height(Length::Fixed(120.0))
                 .spacing(space_xxs)
                 .align_x(Alignment::Center)


### PR DESCRIPTION
Ellipsizes the app names and uses WordGlyph wrapping for apps with long single word names.

Also ellipsizes the category names under its icon and in the title bar.

Fixes https://github.com/pop-os/cosmic-app-library/issues/335 and https://github.com/pop-os/cosmic-app-library/issues/295
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

