### PR TITLE
Reorder groups using DnD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1011,7 +1020,7 @@ dependencies = [
 [[package]]
 name = "cosmic-app-list-config"
 version = "1.0.2"
-source = "git+https://github.com/pop-os/cosmic-applets#45f8a9635c2c067f532dc212e8c966bdfff9733b"
+source = "git+https://github.com/pop-os/cosmic-applets#666f0110d647724d6217832d17df315339e8c7df"
 dependencies = [
  "libcosmic",
  "serde",
@@ -1033,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1054,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "quote",
  "syn",
@@ -1077,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#d518c7d25ef96f1a9696aa8cce008656bf66ece4"
+source = "git+https://github.com/pop-os/cosmic-panel#2358f0473bf68b79f54a0906994a218de211de34"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1105,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#716da6d6af0b252e2f78aba2ad72ee19ae0241e0"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon#fa82bdf9fe7b5f5bd6008f32f393efd5e7a71c47"
 dependencies = [
  "cosmic-config",
  "ron 0.11.0",
@@ -1150,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "almost",
  "configparser",
@@ -1235,10 +1244,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor-lite"
-version = "0.1.2"
+name = "ctor"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "dtor",
+]
 
 [[package]]
 name = "cursor-icon"
@@ -1487,6 +1499,12 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.6.5",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 
 [[package]]
 name = "dyn-clone"
@@ -2060,7 +2078,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2085,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "guillotiere"
@@ -2152,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2286,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2307,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2316,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -2341,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2351,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "futures",
  "iced_core",
@@ -2365,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
@@ -2386,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -2395,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2407,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -2423,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2440,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.1",
@@ -2471,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -2490,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "cosmic-client-toolkit",
  "cursor-icon",
@@ -2627,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2652,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "image-extras"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d29ba92ef6970a2685cc758b455d190842b8b9e96c865ffd31cdb9954b7548"
+checksum = "60d02eb2c9ccbbab470538fce34c7bc3be7b4e59268e65a3171367b296cdb842"
 dependencies = [
  "image",
 ]
@@ -2693,7 +2711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2771,9 +2789,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -2786,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2880,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2947,11 +2965,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -2990,14 +3008,14 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#99c038a66ac721e6af9ca058aa5038ca279d9d0c"
+source = "git+https://github.com/pop-os/libcosmic#2aa9133f9d3334e8f77bd596c67727a2698e8bed"
 dependencies = [
  "apply",
  "ashpd 0.12.3",
@@ -3075,7 +3093,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3169,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_algorithms"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9815fac08e6fd96733a11dce4f9d15a3f338e96a2e2311ee21e1b738efc2bc0f"
+checksum = "8575c0d003ae459399623c4def180c63b77f343b1a7fee64f249b349e7699a31"
 dependencies = [
  "lyon_path",
  "num-traits",
@@ -3679,9 +3697,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.51"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
+checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
 dependencies = [
  "libc",
  "libredox",
@@ -3833,7 +3851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3900,18 +3918,18 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4007,9 +4025,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -4119,15 +4137,15 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -4137,21 +4155,12 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4177,9 +4186,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -4259,9 +4268,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4647,11 +4656,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4666,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4736,9 +4746,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skrifa"
@@ -5103,12 +5113,12 @@ dependencies = [
 
 [[package]]
 name = "tiny-xlib"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
 dependencies = [
  "as-raw-xcb-connection",
- "ctor-lite",
+ "ctor",
  "libloading",
  "pkg-config",
  "tracing",
@@ -5142,9 +5152,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5206,7 +5216,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -5215,7 +5225,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -5276,9 +5286,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
@@ -5451,9 +5461,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -5484,11 +5494,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -5497,14 +5507,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5515,9 +5525,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5525,9 +5535,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5535,9 +5545,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5548,9 +5558,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -5724,7 +5734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml",
  "quote",
 ]
 
@@ -5755,9 +5765,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6507,7 +6517,7 @@ dependencies = [
  "libredox",
  "orbclient",
  "raw-window-handle",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
  "smol_str",
  "tracing",
  "winit-core",
@@ -6622,18 +6632,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -6646,6 +6647,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -6780,7 +6787,7 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#d518c7d25ef96f1a9696aa8cce008656bf66ece4"
+source = "git+https://github.com/pop-os/cosmic-panel#2358f0473bf68b79f54a0906994a218de211de34"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",
@@ -6890,9 +6897,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6918,7 +6925,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.15",
+ "winnow",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6950,9 +6957,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6965,22 +6972,22 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441a0064125265655bccc3a6af6bef56814d9277ac83fce48b1cd7e160b80eac"
+checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
 dependencies = [
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "zbus_names",
  "zvariant",
@@ -7014,9 +7021,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -7105,24 +7112,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "url",
- "winnow 0.7.15",
+ "winnow",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7133,13 +7140,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn",
- "winnow 0.7.15",
+ "winnow",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
 use clap::Parser;
+use cosmic::widget::reorderable_flex_row;
 use cosmic::{
     Element,
     app::{Core, CosmicFlags, Settings, Task},
@@ -82,7 +83,7 @@ use log::error;
 use serde::{Deserialize, Serialize};
 use switcheroo_control::Gpu;
 
-use crate::app_group::AppLibraryConfig;
+use crate::app_group::{AppGroup, AppLibraryConfig};
 use crate::fl;
 use crate::subscriptions::desktop_files::desktop_files;
 use crate::widgets::application::{AppletString, ApplicationButton};
@@ -235,12 +236,12 @@ struct CosmicAppLibrary {
     menu: Option<usize>,
     helper: Option<Config>,
     config: AppLibraryConfig,
-    cur_group: usize,
+    cur_group: Option<usize>,
     locale: Option<String>,
     edit_name: Option<String>,
     new_group: Option<String>,
     dnd_icon: Option<usize>,
-    offer_group: Option<usize>,
+    offer_group: Option<Option<usize>>,
     waiting_for_filtered: bool,
     scroll_offset: f32,
     core: Core,
@@ -259,6 +260,8 @@ struct CosmicAppLibrary {
     scrollable_id: widget::Id,
     surface_state: SurfaceState,
     hand_over: String,
+    group_keys: Vec<u64>,
+    next_group_key: u64,
 }
 
 impl Default for CosmicAppLibrary {
@@ -294,6 +297,8 @@ impl Default for CosmicAppLibrary {
             scrollable_id: widget::Id::unique(),
             surface_state: SurfaceState::Hidden,
             hand_over: String::default(),
+            group_keys: Default::default(),
+            next_group_key: Default::default(),
         }
     }
 }
@@ -328,7 +333,7 @@ impl CosmicAppLibrary {
             self.edit_name = None;
             self.search_value = "".to_string();
             self.scroll_offset = 0.0;
-            self.cur_group = 0;
+            self.cur_group = None;
             self.load_apps();
             self.needs_clear = true;
             let fetch_gpus = Task::perform(try_get_gpus(), |gpus| {
@@ -390,6 +395,13 @@ impl CosmicAppLibrary {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum GroupRowKey {
+    Home,
+    Custom(u64),
+    NewGroup,
+}
+
 #[derive(Clone, Debug)]
 enum Message {
     Activate,
@@ -403,7 +415,8 @@ enum Message {
     ActivateApp(usize, Option<usize>),
     StartCurAppFocus,
     ActivationToken(Option<String>, String, String, Option<usize>, bool),
-    SelectGroup(usize),
+    SelectGroup(Option<usize>),
+    ReorderGroup(Vec<GroupRowKey>),
     Delete(usize),
     ConfirmDelete,
     CancelDelete,
@@ -422,9 +435,9 @@ enum Message {
     StartDrag(usize),
     FinishDrag(bool),
     CancelDrag,
-    StartDndOffer(usize),
-    FinishDndOffer(usize, Option<DesktopEntryData>),
-    LeaveDndOffer(usize),
+    StartDndOffer(Option<usize>),
+    FinishDndOffer(Option<usize>, Option<DesktopEntryData>),
+    LeaveDndOffer(Option<usize>),
     ScrollYOffset(f32),
     GpuUpdate(Option<Vec<Gpu>>),
     PinToAppTray(usize),
@@ -456,6 +469,13 @@ pub fn menu_control_padding() -> Padding {
 }
 
 impl CosmicAppLibrary {
+    fn current_group(&self) -> &AppGroup {
+        match self.cur_group {
+            None => AppLibraryConfig::home(),
+            Some(i) => &self.config.groups[i],
+        }
+    }
+
     pub fn load_apps(&mut self) {
         let xdg_current_desktop = std::env::var("XDG_CURRENT_DESKTOP").ok();
         self.all_entries = cosmic::desktop::load_applications(
@@ -546,7 +566,7 @@ impl CosmicAppLibrary {
         self.new_group = None;
         self.search_value.clear();
         self.edit_name = None;
-        self.cur_group = 0;
+        self.cur_group = None;
         self.menu = None;
         self.group_to_delete = None;
         self.scroll_offset = 0.0;
@@ -790,23 +810,66 @@ impl cosmic::Application for CosmicAppLibrary {
                 });
                 return self.update(Message::Hide);
             }
-            Message::SelectGroup(i) => {
+            Message::SelectGroup(group) => {
                 self.edit_name = None;
                 self.search_value.clear();
-                self.cur_group = i;
+                self.cur_group = group;
                 self.scroll_offset = 0.0;
-                self.scrollable_id = Id::new(
-                    self.config
-                        .groups()
-                        .get(self.cur_group)
-                        .map(|g| g.name.clone())
-                        .unwrap_or_else(|| "unknown-group".to_string()),
-                );
+                self.scrollable_id = Id::new(format!("group-{}", group.unwrap_or(usize::MAX)));
                 let mut cmds = vec![self.filter_apps()];
-                if self.cur_group == 0 {
+                if self.cur_group.is_none() {
                     cmds.push(text_input::focus(SEARCH_ID.clone()));
                 }
                 return iced::Task::batch(cmds);
+            }
+            Message::ReorderGroup(new_order) => {
+                let prev_selected_key =
+                    self.cur_group.and_then(|i| self.group_keys.get(i).copied());
+
+                let reorder_keys: Vec<u64> = new_order
+                    .into_iter()
+                    .filter_map(|key| match key {
+                        GroupRowKey::Custom(k) => Some(k),
+                        GroupRowKey::Home | GroupRowKey::NewGroup => None,
+                    })
+                    .collect();
+
+                if reorder_keys.len() != self.config.groups.len() {
+                    return Task::none();
+                }
+
+                let key_to_index: HashMap<u64, usize> = self
+                    .group_keys
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &k)| (k, i))
+                    .collect();
+
+                let reordered: Vec<crate::app_group::AppGroup> = reorder_keys
+                    .iter()
+                    .filter_map(|k| {
+                        key_to_index
+                            .get(k)
+                            .and_then(|&i| self.config.groups.get(i).cloned())
+                    })
+                    .collect();
+
+                if reordered.len() != self.config.groups.len() {
+                    return Task::none();
+                }
+
+                self.config.groups = reordered;
+                self.group_keys = reorder_keys.clone();
+
+                if let Some(key) = prev_selected_key {
+                    self.cur_group = reorder_keys.iter().position(|&k| k == key);
+                }
+
+                if let Some(helper) = self.helper.as_ref()
+                    && let Err(err) = self.config.write_entry(helper)
+                {
+                    error!("{:?}", err);
+                }
             }
             Message::LoadApps => {
                 return self.filter_apps();
@@ -829,8 +892,10 @@ impl cosmic::Application for CosmicAppLibrary {
                 self.edit_name = Some(name);
             }
             Message::SubmitName => {
-                if let Some(name) = self.edit_name.take() {
-                    self.config.set_name(self.cur_group, name);
+                if let Some(name) = self.edit_name.take()
+                    && let Some(i) = self.cur_group
+                {
+                    self.config.set_name(i, name);
                 }
                 if let Some(helper) = self.helper.as_ref()
                     && let Err(err) = self.config.write_entry(helper)
@@ -865,6 +930,8 @@ impl cosmic::Application for CosmicAppLibrary {
             Message::SubmitNewGroup => {
                 if let Some(group_name) = self.new_group.take() {
                     self.config.add(group_name);
+                    self.group_keys.push(self.next_group_key);
+                    self.next_group_key += 1;
                 }
                 if let Some(helper) = self.helper.as_ref()
                     && let Err(err) = self.config.write_entry(helper)
@@ -969,23 +1036,23 @@ impl cosmic::Application for CosmicAppLibrary {
             Message::CancelDrag => {
                 self.dnd_icon = None;
             }
-            Message::StartDndOffer(i) => {
-                self.offer_group = Some(i);
+            Message::StartDndOffer(group) => {
+                self.offer_group = Some(group);
             }
-            Message::FinishDndOffer(i, entry) => {
+            Message::FinishDndOffer(group, entry) => {
                 self.offer_group = None;
                 let Some(entry) = entry else {
                     return Task::none();
                 };
-                self.config.add_entry(i, &entry.id);
+                self.config.add_entry(group, &entry.id);
                 if let Some(helper) = self.helper.as_ref()
                     && let Err(err) = self.config.write_entry(helper)
                 {
                     error!("{:?}", err);
                 }
             }
-            Message::LeaveDndOffer(i) => {
-                self.offer_group = self.offer_group.filter(|g| *g != i);
+            Message::LeaveDndOffer(group) => {
+                self.offer_group = self.offer_group.filter(|g| *g != group);
             }
             Message::ScrollYOffset(y) => {
                 self.scroll_offset = y;
@@ -994,12 +1061,15 @@ impl cosmic::Application for CosmicAppLibrary {
                 let mut cmds = vec![destroy_layer_surface(*DELETE_GROUP_WINDOW_ID)];
                 if let Some(group) = self.group_to_delete.take() {
                     self.config.remove(group);
+                    if group < self.group_keys.len() {
+                        self.group_keys.remove(group);
+                    }
                     if let Some(helper) = self.helper.as_ref()
                         && let Err(err) = self.config.write_entry(helper)
                     {
                         error!("{:?}", err);
                     }
-                    self.cur_group = 0;
+                    self.cur_group = None;
                     cmds.push(self.filter_apps());
                 }
                 return Task::batch(cmds);
@@ -1211,7 +1281,7 @@ impl cosmic::Application for CosmicAppLibrary {
             list_column.push(divider::horizontal::light().into());
             list_column.push(pin_to_app_tray.into());
 
-            if self.cur_group > 0 {
+            if self.cur_group.is_some() {
                 list_column.push(divider::horizontal::light().into());
                 list_column.push(
                     menu_button(text::body(REMOVE.clone()))
@@ -1303,8 +1373,8 @@ impl cosmic::Application for CosmicAppLibrary {
             return autosize(dialog, DELETE_GROUP_AUTOSIZE_ID.clone()).into();
         }
 
-        let cur_group = self.config.groups()[self.cur_group];
-        let top_row = if self.cur_group == 0 {
+        let cur_group = self.current_group();
+        let top_row = if self.cur_group.is_none() {
             row![
                 container(
                     search_input(SEARCH_PLACEHOLDER.as_str(), self.search_value.as_str())
@@ -1368,7 +1438,7 @@ impl cosmic::Application for CosmicAppLibrary {
                             )
                             .padding(space_xs)
                             .class(Button::Icon)
-                            .on_press(Message::Delete(self.cur_group))
+                            .on_press_maybe(self.cur_group.map(Message::Delete))
                         )
                         .height(Length::Fixed(96.0))
                         .align_y(Vertical::Center),
@@ -1458,116 +1528,103 @@ impl cosmic::Application for CosmicAppLibrary {
         .max_height(444.0);
 
         // TODO use the spacing variables from the theme
-        let (group_icon_size, h_padding, group_width, chunks) = if self.config.groups().len() > 15 {
-            (16.0, space_xxs, 96.0, 11)
+        let (group_icon_size, h_padding, group_width) = if self.config.groups.len() + 1 > 15 {
+            (16.0, space_xxs, 96.0)
         } else {
-            (32.0, space_s, 128.0, 8)
+            (32.0, space_s, 128.0)
         };
         let group_height =
             group_icon_size + 21.0 + (space_none as f32) + (space_xxs as f32) + (space_s as f32);
 
-        let mut add_group_btn = Some(
-            button::custom(
-                column![
-                    container(
-                        icon::icon(icon::from_name("folder-new-symbolic").into())
-                            .width(Length::Fixed(group_icon_size))
-                            .height(Length::Fixed(group_icon_size))
+        let build_group_button = |group_ref: Option<usize>, group: &crate::app_group::AppGroup| {
+            let is_active = self.offer_group == Some(group_ref)
+                || (self.cur_group == group_ref && self.offer_group.is_none());
+            dnd_destination_for_data::<AppletString, Message>(
+                button::custom(
+                    column![
+                        container(
+                            icon::icon(from_name(group.icon.clone()).into())
+                                .width(Length::Fixed(group_icon_size))
+                                .height(Length::Fixed(group_icon_size))
+                        )
+                        .padding(space_xxs),
+                        text::body(group.name()).width(Length::Shrink)
+                    ]
+                    .align_x(Alignment::Center)
+                    .width(Length::Fill),
+                )
+                .height(Length::Fixed(group_height))
+                .width(Length::Fixed(group_width))
+                .class(if is_active {
+                    Button::Custom {
+                        active: Box::new(|focused, theme| {
+                            theme.pressed(focused, false, &Button::IconVertical)
+                        }),
+                        disabled: Box::new(|theme| theme.disabled(&Button::IconVertical)),
+                        hovered: Box::new(|focused, theme| {
+                            theme.hovered(focused, false, &Button::IconVertical)
+                        }),
+                        pressed: Box::new(|focused, theme| {
+                            theme.pressed(focused, false, &Button::IconVertical)
+                        }),
+                    }
+                } else {
+                    Button::IconVertical
+                })
+                .padding([space_none, h_padding, space_xxs, h_padding])
+                .on_press_maybe(
+                    self.menu
+                        .is_none()
+                        .then_some(Message::SelectGroup(group_ref)),
+                ),
+                move |data, _| {
+                    Message::FinishDndOffer(
+                        group_ref,
+                        data.and_then(|data| load_desktop_file(&[], data.0)),
                     )
-                    .padding(space_xxs),
-                    text::body(ADD_GROUP.as_str()).width(Length::Shrink)
-                ]
-                .align_x(Alignment::Center)
-                .width(Length::Fill),
+                },
             )
-            .height(Length::Fixed(group_height))
-            .width(Length::Fixed(group_width))
-            .class(theme::Button::IconVertical)
-            .padding([space_none, h_padding, space_xxs, h_padding])
-            .on_press(Message::StartNewGroup),
-        );
-        let mut group_rows: Vec<_> = self
+            .drag_id(group_ref.map(|i| i as u64 + 1).unwrap_or(0))
+            .on_enter(move |_, _, _| Message::StartDndOffer(group_ref))
+            .on_leave(move || Message::LeaveDndOffer(group_ref))
+        };
+
+        let add_group_btn = button::custom(
+            column![
+                container(
+                    icon::icon(icon::from_name("folder-new-symbolic").into())
+                        .width(Length::Fixed(group_icon_size))
+                        .height(Length::Fixed(group_icon_size))
+                )
+                .padding(space_xxs),
+                text::body(ADD_GROUP.as_str()).width(Length::Shrink)
+            ]
+            .align_x(Alignment::Center)
+            .width(Length::Fill),
+        )
+        .height(Length::Fixed(group_height))
+        .width(Length::Fixed(group_width))
+        .class(theme::Button::IconVertical)
+        .padding([space_none, h_padding, space_xxs, h_padding])
+        .on_press(Message::StartNewGroup);
+
+        let home = AppLibraryConfig::home();
+        let group_row = self
             .config
-            .groups()
-            .chunks(chunks)
+            .groups
+            .iter()
             .enumerate()
-            .map(|(chunk, groups)| {
-                let mut group_row = row![]
+            .fold(
+                reorderable_flex_row::<GroupRowKey, Message>(Message::ReorderGroup)
                     .spacing(space_xxs)
                     .padding([space_s, space_none])
-                    .align_y(Alignment::Center);
-                for (i, group) in groups.iter().enumerate() {
-                    let i = i + chunk * chunks;
-                    let group_button = dnd_destination_for_data::<AppletString, Message>(
-                        button::custom(
-                            column![
-                                container(
-                                    icon::icon(from_name(group.icon.clone()).into())
-                                        .width(Length::Fixed(group_icon_size))
-                                        .height(Length::Fixed(group_icon_size))
-                                )
-                                .padding(space_xxs),
-                                text::body(group.name()).width(Length::Shrink)
-                            ]
-                            .align_x(Alignment::Center)
-                            .width(Length::Fill),
-                        )
-                        .height(Length::Fixed(group_height))
-                        .width(Length::Fixed(group_width))
-                        .class(
-                            if self.offer_group == Some(i)
-                                || (self.cur_group == i && self.offer_group.is_none())
-                            {
-                                // TODO customize the IconVertical to highlight in the way we need
-                                Button::Custom {
-                                    active: Box::new(|focused, theme| {
-                                        theme.pressed(focused, false, &Button::IconVertical)
-                                    }),
-                                    disabled: Box::new(|theme| {
-                                        theme.disabled(&Button::IconVertical)
-                                    }),
-                                    hovered: Box::new(|focused, theme| {
-                                        theme.hovered(focused, false, &Button::IconVertical)
-                                    }),
-                                    pressed: Box::new(|focused, theme| {
-                                        theme.pressed(focused, false, &Button::IconVertical)
-                                    }),
-                                }
-                            } else {
-                                Button::IconVertical
-                            },
-                        )
-                        .padding([space_none, h_padding, space_xxs, h_padding])
-                        .on_press_maybe(self.menu.is_none().then_some(Message::SelectGroup(i))),
-                        move |data, _| {
-                            Message::FinishDndOffer(
-                                i,
-                                data.and_then(|data| load_desktop_file(&[], data.0)),
-                            )
-                        },
-                    )
-                    .on_enter(move |_, _, _| Message::StartDndOffer(i))
-                    .on_leave(move || Message::LeaveDndOffer(i));
-
-                    group_row = group_row.push(group_button);
-                }
-                if groups.len() < chunks {
-                    group_row = group_row.push(add_group_btn.take().unwrap());
-                }
-                group_row
-            })
-            .collect();
-
-        if let Some(add_group_button) = add_group_btn.take() {
-            group_rows.push(
-                row![add_group_button]
-                    .spacing(8)
-                    .padding([space_s, space_none])
-                    .align_y(Alignment::Center),
-            );
-        };
-        let group_rows =
-            Column::with_children(group_rows.into_iter().map(|r| r.into()).collect_vec());
+                    .push_locked(GroupRowKey::Home, build_group_button(None, home)),
+                |row, (i, group)| {
+                    let key = self.group_keys.get(i).copied().unwrap_or(i as u64);
+                    row.push(GroupRowKey::Custom(key), build_group_button(Some(i), group))
+                },
+            )
+            .push_locked(GroupRowKey::NewGroup, add_group_btn);
 
         let content = column![
             top_row,
@@ -1575,7 +1632,7 @@ impl cosmic::Application for CosmicAppLibrary {
             container(horizontal_rule(1))
                 .padding([space_none, space_xxl])
                 .width(Length::Fill),
-            group_rows
+            group_row
         ]
         .align_x(Alignment::Center);
 
@@ -1703,7 +1760,7 @@ impl cosmic::Application for CosmicAppLibrary {
         core.set_keyboard_nav(false);
         let helper = AppLibraryConfig::helper();
 
-        let mut config: AppLibraryConfig = helper
+        let config: AppLibraryConfig = helper
             .as_ref()
             .map(|helper| {
                 AppLibraryConfig::get_entry(helper).unwrap_or_else(|(errors, config)| {
@@ -1714,14 +1771,9 @@ impl cosmic::Application for CosmicAppLibrary {
                 })
             })
             .unwrap_or_default();
-        config.groups.sort();
-        let scrollable_id = Id::new(
-            config
-                .groups()
-                .first()
-                .map(|g| g.name.clone())
-                .unwrap_or_else(|| "unknown-group".to_string()),
-        );
+        let scrollable_id = Id::new("group-home");
+        let group_count = config.groups.len() as u64;
+        let group_keys: Vec<u64> = (0..group_count).collect();
         let self_ = Self {
             locale: std::env::var("LANG")
                 .ok()
@@ -1734,6 +1786,8 @@ impl cosmic::Application for CosmicAppLibrary {
             overlap: HashMap::new(),
             height: 100.,
             scrollable_id,
+            group_keys,
+            next_group_key: group_count,
             ..Default::default()
         };
 

--- a/src/app_group.rs
+++ b/src/app_group.rs
@@ -9,15 +9,13 @@ use serde::{Deserialize, Serialize};
 use std::sync::{Arc, LazyLock};
 use std::vec;
 
-static HOME: LazyLock<[AppGroup; 1]> = LazyLock::new(|| {
-    [AppGroup {
-        name: "cosmic-library-home".to_string(),
-        icon: "user-home-symbolic".to_string(),
-        filter: FilterType::None,
-    }]
+static HOME: LazyLock<AppGroup> = LazyLock::new(|| AppGroup {
+    name: "cosmic-library-home".to_string(),
+    icon: "user-home-symbolic".to_string(),
+    filter: FilterType::None,
 });
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FilterType {
     /// A list of application IDs to include in the group.
     AppIds(Vec<String>),
@@ -66,7 +64,7 @@ impl PartialOrd for FilterType {
 }
 
 // Object holding the state
-#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AppGroup {
     pub name: String,
     pub icon: String,
@@ -181,82 +179,72 @@ impl AppLibraryConfig {
         cosmic_config::Config::new(APP_ID, Self::version()).ok()
     }
 
+    pub fn home() -> &'static AppGroup {
+        &HOME
+    }
+
     pub fn add(&mut self, name: String) {
         self.groups.push(AppGroup {
             name,
             icon: "folder-symbolic".to_string(),
             filter: FilterType::AppIds(Vec::new()),
         });
-        self.groups.sort();
     }
 
     pub fn remove(&mut self, i: usize) {
-        if i == 0 {
-            return;
-        }
-        if i - 1 < self.groups.len() {
-            self.groups.remove(i - 1);
+        if i < self.groups.len() {
+            self.groups.remove(i);
         }
     }
 
     pub fn set_name(&mut self, i: usize, name: String) {
-        if i == 0 {
-            return;
-        }
-        if i - 1 < self.groups.len() {
-            self.groups[i - 1].name = name;
+        if let Some(group) = self.groups.get_mut(i) {
+            group.name = name;
         }
     }
 
-    pub fn remove_entry(&mut self, i: usize, id: &str) {
-        if i == 0 {
+    pub fn remove_entry(&mut self, group: Option<usize>, id: &str) {
+        let Some(group) = group.and_then(|i| self.groups.get_mut(i)) else {
             return;
+        };
+        match &mut group.filter {
+            FilterType::AppIds(ids) => ids.retain(|conf_id| conf_id != id),
+            FilterType::Categories {
+                exclude, include, ..
+            } => {
+                include.retain(|conf_id| conf_id != id);
+                exclude.retain(|conf_id| conf_id != id);
+                exclude.push(id.to_string());
+            }
+            FilterType::None => {}
         }
-        if let Some(group) = self.groups.get_mut(i - 1) {
+    }
+
+    pub fn add_entry(&mut self, group: Option<usize>, id: &str) {
+        if let Some(group) = group.and_then(|i| self.groups.get_mut(i)) {
             match &mut group.filter {
-                FilterType::AppIds(ids) => ids.retain(|conf_id| conf_id != id),
+                FilterType::AppIds(ids) => {
+                    if ids.iter().all(|s| s != id) {
+                        ids.push(id.to_string());
+                    }
+                }
                 FilterType::Categories {
                     exclude, include, ..
                 } => {
                     include.retain(|conf_id| conf_id != id);
                     exclude.retain(|conf_id| conf_id != id);
-                    exclude.push(id.to_string());
+                    include.push(id.to_string());
                 }
                 FilterType::None => {}
             }
-        }
-        if i - 1 < self.groups.len()
-            && let FilterType::AppIds(ids) = &mut self.groups[i - 1].filter
-        {
-            ids.retain(|x| x != id);
-        }
-    }
-
-    pub fn add_entry(&mut self, i: usize, id: &str) {
-        if i > 0 && i - 1 < self.groups.len() {
-            if let FilterType::AppIds(ids) = &mut self.groups[i - 1].filter {
-                if ids.iter().all(|s| s != id) {
-                    ids.push(id.to_string());
-                }
-            } else if let FilterType::Categories {
-                exclude, include, ..
-            } = &mut self.groups[i - 1].filter
-            {
-                include.retain(|conf_id| conf_id != id);
-                exclude.retain(|conf_id| conf_id != id);
-                include.push(id.to_string());
-            }
         } else {
-            // add to filter of all groups, forcing it to the Home group
             for group in &mut self.groups {
                 match &mut group.filter {
                     FilterType::AppIds(ids) => {
                         ids.retain(|conf_id| conf_id != id);
                     }
                     FilterType::Categories {
-                        categories: _,
-                        exclude,
-                        include,
+                        exclude, include, ..
                     } => {
                         include.retain(|conf_id| conf_id != id);
                         if exclude.iter().all(|conf_id| conf_id != id) {
@@ -269,33 +257,20 @@ impl AppLibraryConfig {
         }
     }
 
-    pub fn groups(&self) -> Vec<&AppGroup> {
-        HOME.iter().chain(&self.groups).collect()
-    }
-
     pub fn filtered(
         &self,
-        i: usize,
+        group: Option<usize>,
         input_value: &str,
         entries: &[Arc<DesktopEntryData>],
     ) -> Vec<Arc<DesktopEntryData>> {
-        if i == 0 {
-            HOME[0].filtered(input_value, &self.groups, entries)
-        } else {
-            self._filtered(i - 1, input_value, entries)
+        match group {
+            None => HOME.filtered(input_value, &self.groups, entries),
+            Some(i) => self
+                .groups
+                .get(i)
+                .map(|g| g.filtered(input_value, &Vec::new(), entries))
+                .unwrap_or_default(),
         }
-    }
-
-    pub fn _filtered(
-        &self,
-        i: usize,
-        input_value: &str,
-        entries: &[Arc<DesktopEntryData>],
-    ) -> Vec<Arc<DesktopEntryData>> {
-        self.groups
-            .get(i)
-            .map(|g| g.filtered(input_value, &Vec::new(), entries))
-            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
- Adds ability to reorder the groups manually
- Locks Home and the Add button in place
- Saves the manual order, and removes the auto sort
- ~~You can't have two groups with the same name~~ you can. 
- [x] Depends on https://github.com/pop-os/libcosmic/pull/1272

https://github.com/user-attachments/assets/bf15ccfb-adf9-4ea0-a602-71a5159bd43c

Fixes https://github.com/pop-os/cosmic-app-library/issues/126
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

