### PR TITLE
fix(context-menu): Сontext menu actions broken for apps inside groups

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -979,7 +979,6 @@ impl cosmic::Application for CosmicAppLibrary {
                 return commands::popup::destroy_popup(*MENU_ID);
             }
             Message::SelectAction(action) => {
-                self.menu = None;
                 let mut tasks = vec![commands::popup::destroy_popup(*MENU_ID)];
                 if let Some(info) = self.menu.take().and_then(|i| self.entry_path_input.get(i)) {
                     match action {


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

## Summary
  
  When a user right-clicked an application icon inside a group, the context menu appeared
  correctly but none of its actions had any effect. This was caused by a small but critical
  ordering mistake in the action handler: the menu state was cleared before the app index
  was read from it, so the handler always lost track of which app was clicked and silently
  did nothing.

  Related to #314
  
  ## Steps to reproduce

  1. Open Applications and navigate to any app group (e.g. Office or System)
  2. Right-click any application icon
  3. Select any action from the context menu — **Move to library home** or any app-specific
     action such as "Open New Window"

  ## Before / After

  **Before:** the context menu closes as expected, but the selected action is never
  executed - the app stays in the group and no commands are launched.

  **After:** all context menu actions work correctly - apps are moved back to Library Home
  and app-specific desktop actions are launched as expected.

  ## Impact

  The entire context menu was effectively broken for apps inside groups. Two user-facing
  features were affected:

  * Move to library home - users had no way to remove an app from a group via the UI
  * App desktop actions - shortcuts like "New Private Window" or "Compose Email"
    silently failed to launch

