### PR TITLE
fix: allow NextRow to find ids after FilterApps

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -464,7 +464,7 @@ impl CosmicAppLibrary {
     /// Update entry IDs and their icon handles.
     fn update_entry_metadata(&mut self) {
         self.entry_ids = (0..self.entry_path_input.len())
-            .map(|_| widget::Id::unique())
+            .map(|i| widget::Id::from(format!("app-entry-{i}")))
             .collect();
 
         self.entry_icon_handles = self


### PR DESCRIPTION
This fixes down arrow keys just deselecting the edit after searching for something. Now it correctly selects the first item.

This is a one line fix but the problem is pretty complicated.
The short version: iced Tree reuses Id::Unique ids from the old tree when rebuilding the tree(it does so positionally), the new ids generated by update_entry_metadata in Message::FilterApps are basically instantly stale when the tree is rebuilt and the Message:NextRow won't find the ids in entry_ids after the first assignment.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

