### PR TITLE
Add top/bottom open position for the app library (#336)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -350,12 +350,15 @@ impl CosmicAppLibrary {
                     layer: wlr_layer::Layer::Bottom,
                     keyboard_interactivity: wlr_layer::KeyboardInteractivity::None,
                     input_zone: Some(Vec::new()),
-                    anchor: wlr_layer::Anchor::TOP,
+                    // Anchor to every edge so the sensor spans the whole output.
+                    // A top-only 1200x200 surface could never overlap a bottom
+                    // panel/dock, so bottom-edge detection always saw nothing.
+                    anchor: wlr_layer::Anchor::all(),
                     output:
                         cosmic::iced::runtime::platform_specific::wayland::layer_surface::IcedOutput::Active,
                     namespace: "cosmic_launcher_dummy".into(),
                     margin: IcedMargin::default(),
-                    size: Some((Some(1200), Some(200))),
+                    size: Some((None, None)),
                     exclusive_zone: -1,
                     size_limits: Limits::NONE,
                 }
@@ -434,6 +437,7 @@ impl CosmicAppLibrary {
                     .max(self.size.height - o.y + edge_gap);
             }
         }
+
         let mut cmds = Vec::with_capacity(2);
         // set the padding
         let margin = self.layer_padding();

--- a/src/app.rs
+++ b/src/app.rs
@@ -423,10 +423,15 @@ impl CosmicAppLibrary {
         }
 
         // Detect a bottom-anchored panel/dock: an overlap whose top edge sits in
-        // the lower half of the screen. `bottom_margin` is its exposed height.
+        // the lower half of the screen. `bottom_margin` is the distance from the
+        // screen bottom to the panel's top edge, plus the panel's own edge gap so
+        // the library floats above the panel with matching spacing (not flush).
         for o in self.overlap.values() {
             if o.y >= mid_height {
-                self.bottom_margin = self.bottom_margin.max(self.size.height - o.y);
+                let edge_gap = (self.size.height - (o.y + o.height)).max(0.);
+                self.bottom_margin = self
+                    .bottom_margin
+                    .max(self.size.height - o.y + edge_gap);
             }
         }
         let mut cmds = Vec::with_capacity(2);

--- a/src/app.rs
+++ b/src/app.rs
@@ -93,7 +93,7 @@ use sctk::shell::wlr_layer;
 use serde::{Deserialize, Serialize};
 use switcheroo_control::Gpu;
 
-use crate::app_group::{AppGroup, AppLibraryConfig};
+use crate::app_group::{AppGroup, AppLibraryConfig, LibraryPosition};
 use crate::fl;
 use crate::subscriptions::desktop_files::desktop_files;
 use crate::widgets::application::{AppletString, ApplicationButton};
@@ -261,6 +261,7 @@ struct CosmicAppLibrary {
     app_list_config: AppListConfig,
     overlap: HashMap<String, Rectangle>,
     margin: f32,
+    bottom_margin: f32,
     size: iced::Size,
     needs_clear: bool,
     focused_id: Option<widget::Id>,
@@ -299,6 +300,7 @@ impl Default for CosmicAppLibrary {
             app_list_config: Default::default(),
             overlap: Default::default(),
             margin: Default::default(),
+            bottom_margin: Default::default(),
             size: Size::ZERO,
             needs_clear: Default::default(),
             focused_id: Default::default(),
@@ -407,6 +409,7 @@ impl CosmicAppLibrary {
     fn handle_overlap(&mut self) -> Task<Message> {
         let mid_height = self.size.height / 2.;
         self.margin = 0.;
+        self.bottom_margin = 0.;
 
         for o in self.overlap.values() {
             if self.margin + mid_height < o.y
@@ -417,6 +420,14 @@ impl CosmicAppLibrary {
             }
 
             self.margin = o.y + o.height;
+        }
+
+        // Detect a bottom-anchored panel/dock: an overlap whose top edge sits in
+        // the lower half of the screen. `bottom_margin` is its exposed height.
+        for o in self.overlap.values() {
+            if o.y >= mid_height {
+                self.bottom_margin = self.bottom_margin.max(self.size.height - o.y);
+            }
         }
         let mut cmds = Vec::with_capacity(2);
         // set the padding
@@ -451,13 +462,43 @@ impl CosmicAppLibrary {
         Task::batch(cmds)
     }
 
+    /// Resolve the configured position into a concrete edge (Top or Bottom),
+    /// honoring `Auto` by following the detected panel/dock layout.
+    fn effective_position(&self) -> LibraryPosition {
+        match self.config.position {
+            LibraryPosition::Top => LibraryPosition::Top,
+            LibraryPosition::Bottom => LibraryPosition::Bottom,
+            // Auto: open from the bottom only when there is a bottom dock and no
+            // top panel, so the default top-panel layout is unchanged.
+            LibraryPosition::Auto => {
+                if self.bottom_margin > 0. && self.margin == 0. {
+                    LibraryPosition::Bottom
+                } else {
+                    LibraryPosition::Top
+                }
+            }
+        }
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
     fn layer_padding(&self) -> IcedMargin {
+        let horizontal = ((self.size.width - 1200.) / 2.).max(0.) as i32;
+        let (top, bottom) = match self.effective_position() {
+            LibraryPosition::Bottom => (
+                (self.size.height - 690. - 16. - self.bottom_margin).max(0.) as i32,
+                self.bottom_margin as i32 + 16,
+            ),
+            // Top (and any resolved non-bottom).
+            _ => (
+                self.margin as i32 + 16,
+                (self.size.height - 690. - 16. - self.margin).max(0.) as i32,
+            ),
+        };
         IcedMargin {
-            #[allow(clippy::cast_possible_truncation)]
-            top: self.margin as i32 + 16,
-            left: ((self.size.width - 1200.) / 2.).max(0.) as i32,
-            right: ((self.size.width - 1200.) / 2.).max(0.) as i32,
-            bottom: (self.size.height - 690. - 16. - self.margin).max(0.) as i32,
+            top,
+            left: horizontal,
+            right: horizontal,
+            bottom,
         }
     }
 
@@ -1754,6 +1795,18 @@ impl cosmic::Application for CosmicAppLibrary {
             })))
             .center_x(Length::Fill)
             .width(Length::Fixed(1200.));
+        let window = mouse_area(window).on_press(Message::CloseContextMenu);
+        let positioned = match self.effective_position() {
+            LibraryPosition::Bottom => column!(
+                space::vertical().height(Length::Fill),
+                window,
+                space::vertical().height(Length::Fixed(self.bottom_margin + 16.)),
+            ),
+            _ => column!(
+                space::vertical().height(Length::Fixed(self.margin + 16.)),
+                window,
+            ),
+        };
         stack![
             mouse_area(
                 container(space::horizontal().width(Length::Fill))
@@ -1761,12 +1814,7 @@ impl cosmic::Application for CosmicAppLibrary {
                     .height(Length::Fill)
             )
             .on_press(Message::Hide),
-            column!(
-                space::vertical().height(Length::Fixed(self.margin + 16.)),
-                mouse_area(window).on_press(Message::CloseContextMenu),
-            )
-            .align_x(Alignment::Center)
-            .width(Length::Fill)
+            positioned.align_x(Alignment::Center).width(Length::Fill)
         ]
         .width(Length::Fill)
         .height(Length::Fill)

--- a/src/app_group.rs
+++ b/src/app_group.rs
@@ -165,9 +165,30 @@ impl AppGroup {
     }
 }
 
+/// Which edge of the screen the app library opens from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LibraryPosition {
+    /// Follow the panel/dock: bottom if a bottom dock is present and there is no
+    /// top panel, otherwise top.
+    Auto,
+    /// Always anchor to the top of the screen.
+    Top,
+    /// Always anchor to the bottom of the screen.
+    Bottom,
+}
+
+impl Default for LibraryPosition {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, CosmicConfigEntry)]
 pub struct AppLibraryConfig {
     pub(crate) groups: Vec<AppGroup>,
+    /// Which edge of the screen the library opens from.
+    #[serde(default)]
+    pub position: LibraryPosition,
 }
 
 impl AppLibraryConfig {
@@ -322,6 +343,7 @@ impl Default for AppLibraryConfig {
                     },
                 },
             ],
+            position: LibraryPosition::default(),
         }
     }
 }


### PR DESCRIPTION
Closes #336.

Adds a `position` config key to `AppLibraryConfig` letting the app library open from the top or bottom edge of the screen:

- `LibraryPosition { Auto, Top, Bottom }`, default `Auto` — missing key deserializes to `Auto` via `#[serde(default)]`, so existing configs are unaffected.
- `Auto` follows the panel layout: bottom only when a bottom panel/dock is present **and** there is no top panel; otherwise top. The default COSMIC layout (top panel + bottom dock) still resolves to top, so out-of-the-box behavior is unchanged.
- `Top` / `Bottom` force the respective edge, set via `~/.config/cosmic/com.system76.CosmicAppLibrary/v1/position`.
- `layer_padding()` and the view spacer now branch on the effective position; a `bottom_margin` is computed from overlap-notify so the library floats above a bottom panel/dock with the same edge gap as at the top.
- The overlap sensor surface was anchored to the top edge at a fixed 1200x200, so bottom panels never registered (bottom_margin stayed 0). It now anchors to all edges and stretches to the output, so panels on any edge are detected. Verified on a 78px bottom panel → `bottom_margin = 78`.

Scope is intentionally minimal (position only, no UI toggle). Happy to adjust naming/behavior to match what you'd want upstream.

Used Claude code for some coding and bugfixing.