### PR TITLE
Add a top/bottom open position for the app library (#336)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -93,7 +93,7 @@ use sctk::shell::wlr_layer;
 use serde::{Deserialize, Serialize};
 use switcheroo_control::Gpu;
 
-use crate::app_group::{AppGroup, AppLibraryConfig};
+use crate::app_group::{AppGroup, AppLibraryConfig, LibraryPosition};
 use crate::fl;
 use crate::subscriptions::desktop_files::desktop_files;
 use crate::widgets::application::{AppletString, ApplicationButton};
@@ -261,6 +261,7 @@ struct CosmicAppLibrary {
     app_list_config: AppListConfig,
     overlap: HashMap<String, Rectangle>,
     margin: f32,
+    bottom_margin: f32,
     size: iced::Size,
     needs_clear: bool,
     focused_id: Option<widget::Id>,
@@ -299,6 +300,7 @@ impl Default for CosmicAppLibrary {
             app_list_config: Default::default(),
             overlap: Default::default(),
             margin: Default::default(),
+            bottom_margin: Default::default(),
             size: Size::ZERO,
             needs_clear: Default::default(),
             focused_id: Default::default(),
@@ -348,12 +350,15 @@ impl CosmicAppLibrary {
                     layer: wlr_layer::Layer::Bottom,
                     keyboard_interactivity: wlr_layer::KeyboardInteractivity::None,
                     input_zone: Some(Vec::new()),
-                    anchor: wlr_layer::Anchor::TOP,
+                    // Anchor to every edge so the sensor spans the whole output.
+                    // A top-only 1200x200 surface could never overlap a bottom
+                    // panel/dock, so bottom-edge detection always saw nothing.
+                    anchor: wlr_layer::Anchor::all(),
                     output:
                         cosmic::iced::runtime::platform_specific::wayland::layer_surface::IcedOutput::Active,
                     namespace: "cosmic_launcher_dummy".into(),
                     margin: IcedMargin::default(),
-                    size: Some((Some(1200), Some(200))),
+                    size: Some((None, None)),
                     exclusive_zone: -1,
                     size_limits: Limits::NONE,
                 }
@@ -407,6 +412,7 @@ impl CosmicAppLibrary {
     fn handle_overlap(&mut self) -> Task<Message> {
         let mid_height = self.size.height / 2.;
         self.margin = 0.;
+        self.bottom_margin = 0.;
 
         for o in self.overlap.values() {
             if self.margin + mid_height < o.y
@@ -418,6 +424,20 @@ impl CosmicAppLibrary {
 
             self.margin = o.y + o.height;
         }
+
+        // Detect a bottom-anchored panel/dock: an overlap whose top edge sits in
+        // the lower half of the screen. `bottom_margin` is the distance from the
+        // screen bottom to the panel's top edge, plus the panel's own edge gap so
+        // the library floats above the panel with matching spacing (not flush).
+        for o in self.overlap.values() {
+            if o.y >= mid_height {
+                let edge_gap = (self.size.height - (o.y + o.height)).max(0.);
+                self.bottom_margin = self
+                    .bottom_margin
+                    .max(self.size.height - o.y + edge_gap);
+            }
+        }
+
         let mut cmds = Vec::with_capacity(2);
         // set the padding
         let margin = self.layer_padding();
@@ -451,13 +471,43 @@ impl CosmicAppLibrary {
         Task::batch(cmds)
     }
 
+    /// Resolve the configured position into a concrete edge (Top or Bottom),
+    /// honoring `Auto` by following the detected panel/dock layout.
+    fn effective_position(&self) -> LibraryPosition {
+        match self.config.position {
+            LibraryPosition::Top => LibraryPosition::Top,
+            LibraryPosition::Bottom => LibraryPosition::Bottom,
+            // Auto: open from the bottom only when there is a bottom dock and no
+            // top panel, so the default top-panel layout is unchanged.
+            LibraryPosition::Auto => {
+                if self.bottom_margin > 0. && self.margin == 0. {
+                    LibraryPosition::Bottom
+                } else {
+                    LibraryPosition::Top
+                }
+            }
+        }
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
     fn layer_padding(&self) -> IcedMargin {
+        let horizontal = ((self.size.width - 1200.) / 2.).max(0.) as i32;
+        let (top, bottom) = match self.effective_position() {
+            LibraryPosition::Bottom => (
+                (self.size.height - 690. - 16. - self.bottom_margin).max(0.) as i32,
+                self.bottom_margin as i32 + 16,
+            ),
+            // Top (and any resolved non-bottom).
+            _ => (
+                self.margin as i32 + 16,
+                (self.size.height - 690. - 16. - self.margin).max(0.) as i32,
+            ),
+        };
         IcedMargin {
-            #[allow(clippy::cast_possible_truncation)]
-            top: self.margin as i32 + 16,
-            left: ((self.size.width - 1200.) / 2.).max(0.) as i32,
-            right: ((self.size.width - 1200.) / 2.).max(0.) as i32,
-            bottom: (self.size.height - 690. - 16. - self.margin).max(0.) as i32,
+            top,
+            left: horizontal,
+            right: horizontal,
+            bottom,
         }
     }
 
@@ -1754,6 +1804,18 @@ impl cosmic::Application for CosmicAppLibrary {
             })))
             .center_x(Length::Fill)
             .width(Length::Fixed(1200.));
+        let window = mouse_area(window).on_press(Message::CloseContextMenu);
+        let positioned = match self.effective_position() {
+            LibraryPosition::Bottom => column!(
+                space::vertical().height(Length::Fill),
+                window,
+                space::vertical().height(Length::Fixed(self.bottom_margin + 16.)),
+            ),
+            _ => column!(
+                space::vertical().height(Length::Fixed(self.margin + 16.)),
+                window,
+            ),
+        };
         stack![
             mouse_area(
                 container(space::horizontal().width(Length::Fill))
@@ -1761,12 +1823,7 @@ impl cosmic::Application for CosmicAppLibrary {
                     .height(Length::Fill)
             )
             .on_press(Message::Hide),
-            column!(
-                space::vertical().height(Length::Fixed(self.margin + 16.)),
-                mouse_area(window).on_press(Message::CloseContextMenu),
-            )
-            .align_x(Alignment::Center)
-            .width(Length::Fill)
+            positioned.align_x(Alignment::Center).width(Length::Fill)
         ]
         .width(Length::Fill)
         .height(Length::Fill)

--- a/src/app_group.rs
+++ b/src/app_group.rs
@@ -165,9 +165,30 @@ impl AppGroup {
     }
 }
 
+/// Which edge of the screen the app library opens from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LibraryPosition {
+    /// Follow the panel/dock: bottom if a bottom dock is present and there is no
+    /// top panel, otherwise top.
+    Auto,
+    /// Always anchor to the top of the screen.
+    Top,
+    /// Always anchor to the bottom of the screen.
+    Bottom,
+}
+
+impl Default for LibraryPosition {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, CosmicConfigEntry)]
 pub struct AppLibraryConfig {
     pub(crate) groups: Vec<AppGroup>,
+    /// Which edge of the screen the library opens from.
+    #[serde(default)]
+    pub position: LibraryPosition,
 }
 
 impl AppLibraryConfig {
@@ -322,6 +343,7 @@ impl Default for AppLibraryConfig {
                     },
                 },
             ],
+            position: LibraryPosition::default(),
         }
     }
 }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Closes #336.

*(Replaces #388 — same feature, resubmitted as a single reviewed commit with a complete description.)*

## Summary

Adds a `position` config key so the app library can open from the top or the bottom edge of the screen instead of always the top. This is the feature requested in #336, where users with a bottom dock want the library to appear near it.

- `LibraryPosition { Auto, Top, Bottom }`, default `Auto`. The field is `#[serde(default)]`, so configs without the key deserialize to `Auto` and **existing installs are unaffected**.
- `Auto` follows the panel layout: the library opens from the bottom **only** when a bottom panel/dock is present and there is no top panel. The default COSMIC layout (top panel + bottom dock) still resolves to top, so out-of-the-box behavior is unchanged.
- `Top` / `Bottom` force the respective edge.
- When opening from the bottom, the library floats above a bottom panel/dock by the panel's height plus its edge gap — the same spacing the top edge already gets — rather than overlapping the panel.

## How it works

1. **Bottom-panel detection.** The hidden overlap-sensor layer surface was a 1200×200 strip anchored to the top edge, so bottom panels never overlapped it and could not be detected. It now spans the whole output (`Anchor::all()`, unbounded size). It remains input-transparent and on the `Bottom` layer, so nothing else changes.
2. **`handle_overlap()`** records a new `bottom_margin` from overlapping panel surfaces whose top edge is in the lower half of the screen, using the same panel/dock criteria as the existing top-margin logic (exclusive zone > 0, or the `Panel`/`Dock` namespaces).
3. **`layer_padding()`** picks its top/bottom padding based on the resolved position, and the main view places the window with matching spacers so the backdrop click-to-dismiss regions and layout follow the chosen edge.

## Testing done

On a live COSMIC session (CachyOS, cosmic-comp 1.3.0, 1920×1080 and 2880×1800@1.5x):

- No config key set + default layout (top panel + bottom dock): opens from the top, identical to current behavior.
- No key + only a bottom dock: opens from the bottom, floating above the dock with matching gap.
- `Top` / `Bottom` set explicitly: forced edge respected in both layouts.
- Removed the config key afterwards: falls back to `Auto` cleanly (serde default), no panic, no stale state.

To set the key manually:

```
# ~/.config/cosmic/com.system76.CosmicAppLibrary/v1/position
Bottom
```

(values: `Auto`, `Top`, `Bottom`; take effect on next open)

## AI disclosure

Parts of this change were drafted with an LLM coding assistant. I have reviewed and understand all of it, the commit message discloses this, and I will respond to review comments myself.
